### PR TITLE
Amended the Anawaert KMS Server Address since the previous one was deprecated.

### DIFF
--- a/KMS Activator.csproj
+++ b/KMS Activator.csproj
@@ -12,7 +12,7 @@
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <Title>Anawaert Activator</Title>
     <PackageId>Anawaert Activator</PackageId>
-    <Version>2.0.0.0</Version>
+    <Version>2.0.0.1</Version>
     <Authors>Anawaert</Authors>
     <Company>Anawaert Studio</Company>
     <Product>Anawaert Activator</Product>
@@ -24,8 +24,8 @@
     <NeutralLanguage>zh-CN</NeutralLanguage>
     <PackageReleaseNotes>用于Windows与Office的激活工具</PackageReleaseNotes>
     <Description>用于Windows与Office的激活工具</Description>
-    <FileVersion>2.0.0.0</FileVersion>
-    <AssemblyVersion>2.0.0.0</AssemblyVersion>
+    <FileVersion>2.0.0.1</FileVersion>
+    <AssemblyVersion>2.0.0.1</AssemblyVersion>
     <RepositoryUrl>https://github.com/Anawaert/WPF-KMS-Activator</RepositoryUrl>
     <SignAssembly>False</SignAssembly>
     <AssemblyOriginatorKeyFile>C:\Users\Adam\Desktop\Release\kmscert.pfx</AssemblyOriginatorKeyFile>

--- a/Shared_Code/Shared.cs
+++ b/Shared_Code/Shared.cs
@@ -359,7 +359,7 @@ namespace KMS_Activator
 
                 // 再从<a></a>组成的“小”字符串中匹配版本号，第一个匹配就是最新版本的版本号
                 Match versionNumsMatch = getVersionNumsRegex.Match(a_tags_string_builder.ToString());
-                if (versionNumsMatch.Value != "2.0.0.0" && versionNumsMatch.Success)
+                if (versionNumsMatch.Value != "2.0.0.1" && versionNumsMatch.Success)
                 {
                     MessageBoxResult result = MessageBox.Show
                     (

--- a/Shared_Code/Shared.cs
+++ b/Shared_Code/Shared.cs
@@ -42,7 +42,7 @@ namespace KMS_Activator
         ///         This value is the address of Anawaert KMS server
         ///     </para>
         /// </summary>
-        public const string AW_KMS_SERVER_ADDR = "www.anawaert.tech";
+        public const string AW_KMS_SERVER_ADDR = "anawaert.com";
         /// <summary>
         ///     <para>
         ///         该静态变量指示当前应用程序运行时所在的目录


### PR DESCRIPTION
The previous Anawaert KMS Server address was anawaert.tech. The address is now anawaert.com. This pull request is for the purpose of correcting the problem while users select the option "Anawaert 服务器".